### PR TITLE
add linux specific header and silence errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ class BuildV8Command(Command):
         if not v8_exists():
             get_v8()
             with cd('v8'):
-                gypflags = '-Dv8_use_external_startup_data=0 -Dv8_enable_i18n_support=0 -Dv8_enable_inspector=1'
+                gypflags = '-Dv8_use_external_startup_data=0 -Dv8_enable_i18n_support=0 -Dv8_enable_inspector=1 -Dwerror=\'\' '
                 run('make GYPFLAGS="{}" CFLAGS=-fPIC CXXFLAGS=-fPIC {} -j{}'.format(gypflags, MODE, multiprocessing.cpu_count()))
 
 class build_ext(distutils_build_ext):

--- a/v8py/debugger.cpp
+++ b/v8py/debugger.cpp
@@ -1,6 +1,8 @@
 #include <Python.h>
 #include <v8.h>
-
+#if defined(V8_OS_LINUX)
+# include <arpa/inet.h>
+#endif
 #include "context.h"
 #include "debugger.h"
 


### PR DESCRIPTION
-Werror flag was causing the build to fail. Primarily due to new
 warnings in gcc 5.4.0. Only reliable way to disable it was the
 gypflags.

Add arpa/inet.h for htos if on linux. Other platforms may need it.