### PR TITLE
Added "timeout" argument for a JSFunction call

### DIFF
--- a/v8py/context.h
+++ b/v8py/context.h
@@ -17,6 +17,8 @@ typedef struct {
 } context_c;
 int context_type_init();
 
+void *breaker_thread(void *param);
+
 void context_dealloc(context_c *self);
 PyObject *context_new(PyTypeObject *type, PyObject *args, PyObject *kwargs);
 PyObject *context_eval(context_c *self, PyObject *args, PyObject *kwargs);

--- a/v8py/jsfunction.cpp
+++ b/v8py/jsfunction.cpp
@@ -1,9 +1,11 @@
 #include <Python.h>
 #include <v8.h>
+#include <pthread.h>
 
 #include "v8py.h"
 #include "jsobject.h"
 #include "convert.h"
+#include "context.h"
 
 PyTypeObject js_function_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -34,7 +36,39 @@ PyObject *js_function_call(js_function *self, PyObject *args, PyObject *kwargs) 
     int argc = PyTuple_GET_SIZE(args);
     Local<Value> *argv = new Local<Value>[argc];
     jss_from_pys(args, argv, context);
+
+    double timeout = 0;
+    if (kwargs) {
+        PyObject *timeoutObj = PyDict_GetItemString(kwargs, "timeout");
+        if (timeoutObj) {
+            if (!PyFloat_Check(timeoutObj)) {
+                PyErr_SetString(PyExc_TypeError, "timeout argument must be a float");
+                return NULL;
+            }
+            timeout = PyFloat_AS_DOUBLE(timeoutObj);
+        }
+    }
+
+    pthread_t breaker_id;
+    if (timeout > 0) {
+        errno = pthread_create(&breaker_id, NULL, breaker_thread, &timeout);
+        if (errno) {
+            PyErr_SetFromErrno(PyExc_OSError);
+            return NULL;
+        }
+    }
+
     MaybeLocal<Value> result = object->CallAsFunction(context, js_this, argc, argv);
+
+    if (timeout > 0) {
+        pthread_cancel(breaker_id);
+        errno = pthread_join(breaker_id, NULL);
+        if (errno) {
+            PyErr_SetFromErrno(PyExc_OSError);
+            return NULL;
+        }
+    }
+
     delete[] argv;
     PY_PROPAGATE_JS;
     return py_from_js(result.ToLocalChecked(), context);


### PR DESCRIPTION
`JSFunction`'s `__call__` method lacks the timeout functionality like `eval` has.

```javascript
function freeze() {
    while(true) {};
}
```
Calling `freeze` method will hang python for good:
```python
ctx = Context()
ctx.eval( [ code above ] )
ctx.glob.freeze() # will never return
```

This pull request solves the issue like `eval`, adding optional `timeout` argument to **kwargs:

```python
ctx = Context()
ctx.eval( [ code above ] )
try:
    ctx.glob.freeze(timeout=1.0)
except JavaScriptTerminated:
    pass
```