### PR TITLE
Call PyErr_Clear() after failing to import greenstack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: python
 python:
     - 2.7
     - 3.5
-script: ./setup.py test
+script:
+    - ./setup.py test
+    - pip uninstall -y greenstack && ./setup.py develop && python -c "import v8py"
 
 dist: trusty
 sudo: false

--- a/v8py/greenstack.cpp
+++ b/v8py/greenstack.cpp
@@ -67,6 +67,7 @@ int greenstack_init() {
     PyGreenstack_Import();
     if (_PyGreenstack_API == NULL) {
         // No greenlets? No problems!
+        PyErr_Clear();
         return 0;
     }
     if (PyGreenstack_AddStateHandler(greenstack_switch_v8, greenstack_init_v8) < 0) {


### PR DESCRIPTION
I haven't been able to actually test the change in the non-PyCapsule path because of issues with Python 2.6 on my system, but the PyCapsule_Import path works for me in 3.5.2 and 2.7.12 so I included it by analogy.