### PR TITLE
Added Promise support

### DIFF
--- a/tests/test_promise.py
+++ b/tests/test_promise.py
@@ -1,0 +1,7 @@
+
+from v8py import JSPromise
+
+def test_promise(context):
+    context.eval('async function p() { return 5; }')
+    promise = context.glob.p()
+    assert isinstance(promise, JSPromise)

--- a/v8py/jsobject.h
+++ b/v8py/jsobject.h
@@ -38,4 +38,16 @@ PyObject *js_function_call(js_function *self, PyObject *args, PyObject *kwargs);
 PyObject *js_function_new(js_function *self, PyObject *args);
 void js_function_dealloc(js_function *self);
 
+typedef struct {
+    PyObject_HEAD
+    Persistent<Object> object;
+    Persistent<Context> context;
+} js_promise;
+extern PyTypeObject js_promise_type;
+int js_promise_type_init();
+
+PyObject *js_promise_new(js_promise *self, PyObject *args);
+void js_promise_dealloc(js_promise *self);
+
+
 #endif

--- a/v8py/v8py.cpp
+++ b/v8py/v8py.cpp
@@ -172,6 +172,10 @@ PyMODINIT_FUNC PyInit__v8py() {
     Py_INCREF(&js_object_type);
     PyModule_AddObject(module, "JSObject", (PyObject *) &js_object_type);
 
+    if (js_promise_type_init() < 0) return FAIL;
+    Py_INCREF(&js_promise_type);
+    PyModule_AddObject(module, "JSPromise", (PyObject *) &js_promise_type);
+
     if (js_function_type_init() < 0) return FAIL;
     Py_INCREF(&js_function_type);
     PyModule_AddObject(module, "JSFunction", (PyObject *) &js_function_type);


### PR DESCRIPTION
So `async`/`await` can be handled by python and used in asynchronous frameworks.

```javascript
async function test()
{
    await sleep(..)
    return 5;
}
```

When `async` function is called, Javascript returns `Promise`. This commit adds a way to detect one reliably:

```python
from v8py import JSPromise

result = context.glob.test()
if isinstance(result, JSPromise):
    pass # this function is async, handle it async-way
```