### PR TITLE
Added timeout implementation per-context level

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,3 +5,7 @@ from v8py import Context
 def context():
     return Context()
 
+@pytest.fixture
+def context_with_timeout():
+    return Context(timeout=0.1)
+

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -41,7 +41,7 @@ def test_timeout_property(context_with_timeout):
     diff = time.time() - start
     assert diff >= 0.25 and diff < 0.3
 
-def test_timeout_cotext_level(context_with_timeout):
+def test_timeout_context_level(context_with_timeout):
     with pytest.raises(JavaScriptTerminated):
         context_with_timeout.eval('for(;;) {}')
 
@@ -60,7 +60,7 @@ def test_timeout_proxy(context_with_timeout):
         user = {};
         user.testA = 0;
         user.testC = 10;
-        
+
         proxy = new Proxy(user, {
           get(target, prop) {
             if (prop == "testA") while(true);

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,7 +1,7 @@
 import pytest
 import time
 
-from v8py import JavaScriptTerminated, current_context
+from v8py import JavaScriptTerminated, current_context, new
 
 def test_glob(context):
     context.eval('foo = "bar"')
@@ -44,6 +44,11 @@ def test_timeout_property(context_with_timeout):
 def test_timeout_cotext_level(context_with_timeout):
     with pytest.raises(JavaScriptTerminated):
         context_with_timeout.eval('for(;;) {}')
+
+def test_timeout_new(context_with_timeout):
+    context_with_timeout.eval('function Freeze() { while(true); }')
+    with pytest.raises(JavaScriptTerminated):
+        new(context_with_timeout.glob.Freeze)
 
 def test_timeout_call(context_with_timeout):
     context_with_timeout.eval('function freeze() { while(true); }')

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,4 +1,6 @@
 import pytest
+import time
+
 from v8py import JavaScriptTerminated, current_context
 
 def test_glob(context):
@@ -20,6 +22,65 @@ def test_getitem(context):
 def test_timeout(context):
     with pytest.raises(JavaScriptTerminated):
         context.eval('for(;;) {}', timeout=0.1)
+
+def test_timeout_property(context_with_timeout):
+    assert context_with_timeout.timeout == 0.1
+
+    start = time.time()
+    with pytest.raises(JavaScriptTerminated):
+        context_with_timeout.eval('for(;;) {}')
+    diff = time.time() - start
+    assert diff >= 0.1 and diff < 0.2
+
+    context_with_timeout.timeout = 0.25
+    assert context_with_timeout.timeout == 0.25
+
+    start = time.time()
+    with pytest.raises(JavaScriptTerminated):
+        context_with_timeout.eval('for(;;) {}')
+    diff = time.time() - start
+    assert diff >= 0.25 and diff < 0.3
+
+def test_timeout_cotext_level(context_with_timeout):
+    with pytest.raises(JavaScriptTerminated):
+        context_with_timeout.eval('for(;;) {}')
+
+def test_timeout_call(context_with_timeout):
+    context_with_timeout.eval('function freeze() { while(true); }')
+    with pytest.raises(JavaScriptTerminated):
+        context_with_timeout.glob.freeze()
+
+def test_timeout_proxy(context_with_timeout):
+    context_with_timeout.eval("""
+        user = {};
+        user.testA = 0;
+        user.testC = 10;
+        
+        proxy = new Proxy(user, {
+          get(target, prop) {
+            if (prop == "testA") while(true);
+          },
+          set(target, prop, value) {
+            if (prop == "testB") while(true);
+            return false;
+          },
+          deleteProperty(target, phrase) {
+            if (phrase == "testC") while(true);
+            return false;
+          }
+        });
+    """)
+
+    proxy = context_with_timeout.glob.proxy
+
+    with pytest.raises(JavaScriptTerminated):
+        testA = proxy.testA
+
+    with pytest.raises(JavaScriptTerminated):
+        proxy.testB = 5
+
+    with pytest.raises(JavaScriptTerminated):
+        del proxy.testC
 
 def test_expose(context):
     def f(): return 'f'

--- a/v8py/context.h
+++ b/v8py/context.h
@@ -18,8 +18,8 @@ typedef struct {
 } context_c;
 int context_type_init();
 
-bool setup_timeout(double timeout);
-bool cleanup_timeout(double timeout);
+bool context_setup_timeout(Local<Context> context);
+bool context_cleanup_timeout(Local<Context> context);
 
 void context_dealloc(context_c *self);
 PyObject *context_new(PyTypeObject *type, PyObject *args, PyObject *kwargs);

--- a/v8py/context.h
+++ b/v8py/context.h
@@ -14,8 +14,12 @@ typedef struct {
     PyObject *js_object_cache;
     PyObject *scripts;
     bool has_debugger;
+    double timeout;
 } context_c;
 int context_type_init();
+
+bool setup_timeout(double timeout);
+bool cleanup_timeout(double timeout);
 
 void context_dealloc(context_c *self);
 PyObject *context_new(PyTypeObject *type, PyObject *args, PyObject *kwargs);
@@ -34,6 +38,9 @@ void context_set_cached_jsobject(Local<Context> context, PyObject *py_object, Lo
 
 PyObject *context_get_current(PyObject *shit, PyObject *fuck);
 PyObject *context_get_global(context_c *self, void *shit);
+
+PyObject *context_get_timeout(context_c *self, void *shit);
+int *context_set_timeout(context_c *self, PyObject *value, void *shit);
 
 PyObject *context_getattro(context_c *self, PyObject *name);
 PyObject *context_getitem(context_c *self, PyObject *name);

--- a/v8py/debug.py
+++ b/v8py/debug.py
@@ -1,8 +1,13 @@
 import _v8py
 
+
+class PlainDebugger(_v8py.Debugger):
+    pass
+
+
 class Debugger(_v8py.Debugger):
     def __init__(self, context):
-        super(self.__class__, self).__init__(context)
+        _v8py.Debugger.__init__(self, context)
         self.sequence = 0
         self.last_message = None
         self.loop_nesting = 0

--- a/v8py/jsfunction.cpp
+++ b/v8py/jsfunction.cpp
@@ -27,12 +27,6 @@ PyObject *js_function_call(js_function *self, PyObject *args, PyObject *kwargs) 
     IN_CONTEXT(self->context.Get(isolate));
     JS_TRY
 
-    double timeout = 0;
-    {
-        context_c *ctx_c = (context_c *) context->GetEmbedderData(CONTEXT_OBJECT_SLOT).As<External>()->Value();
-        timeout = ctx_c->timeout;
-    }
-
     Local<Object> object = self->object.Get(isolate);
     Local<Value> js_this;
     if (self->js_this.IsEmpty()) {

--- a/v8py/jsfunction.cpp
+++ b/v8py/jsfunction.cpp
@@ -44,10 +44,10 @@ PyObject *js_function_call(js_function *self, PyObject *args, PyObject *kwargs) 
     Local<Value> *argv = new Local<Value>[argc];
     jss_from_pys(args, argv, context);
 
-    if (!setup_timeout(timeout)) return NULL;
+    if (!context_setup_timeout(context)) return NULL;
     MaybeLocal<Value> result = object->CallAsFunction(context, js_this, argc, argv);
     delete[] argv;
-    if (!cleanup_timeout(timeout)) return NULL;
+    if (!context_cleanup_timeout(context)) return NULL;
     PY_PROPAGATE_JS;
     return py_from_js(result.ToLocalChecked(), context);
 }

--- a/v8py/jsfunction.cpp
+++ b/v8py/jsfunction.cpp
@@ -46,9 +46,8 @@ PyObject *js_function_call(js_function *self, PyObject *args, PyObject *kwargs) 
 
     if (!setup_timeout(timeout)) return NULL;
     MaybeLocal<Value> result = object->CallAsFunction(context, js_this, argc, argv);
-    if (!cleanup_timeout(timeout)) return NULL;
-
     delete[] argv;
+    if (!cleanup_timeout(timeout)) return NULL;
     PY_PROPAGATE_JS;
     return py_from_js(result.ToLocalChecked(), context);
 }

--- a/v8py/jsobject.cpp
+++ b/v8py/jsobject.cpp
@@ -77,12 +77,6 @@ PyObject *js_object_getattro(js_object *self, PyObject *name) {
     Local<Value> js_name = js_from_py(name, context);
     JS_TRY
 
-    double timeout = 0;
-    {
-        context_c *ctx_c = (context_c *) context->GetEmbedderData(CONTEXT_OBJECT_SLOT).As<External>()->Value();
-        timeout = ctx_c->timeout;
-    }
-
     if (!context_setup_timeout(context)) return NULL;
     if (!object->Has(context, js_name).FromJust()) {
         // TODO fix this so that it works
@@ -128,12 +122,6 @@ int js_object_setattro(js_object *self, PyObject *name, PyObject *value) {
 
     Local<Object> object = self->object.Get(isolate);
 
-    double timeout = 0;
-    {
-        context_c *ctx_c = (context_c *) context->GetEmbedderData(CONTEXT_OBJECT_SLOT).As<External>()->Value();
-        timeout = ctx_c->timeout;
-    }
-
     if (!context_setup_timeout(context)) return -1;
 
     if (value != NULL)
@@ -168,12 +156,6 @@ PyObject *js_object_dir(js_object *self) {
     Local<Array> properties = maybe_properties.ToLocalChecked();
     PyObject *py_properties = PyList_New(properties->Length());
     PyErr_PROPAGATE(py_properties);
-
-    double timeout = 0;
-    {
-        context_c *ctx_c = (context_c *) context->GetEmbedderData(CONTEXT_OBJECT_SLOT).As<External>()->Value();
-        timeout = ctx_c->timeout;
-    }
 
     if (!context_setup_timeout(context)) return NULL;
     for (unsigned i = 0; i < properties->Length(); i++) {

--- a/v8py/jsobject.cpp
+++ b/v8py/jsobject.cpp
@@ -83,7 +83,7 @@ PyObject *js_object_getattro(js_object *self, PyObject *name) {
         timeout = ctx_c->timeout;
     }
 
-    if (!setup_timeout(timeout)) return NULL;
+    if (!context_setup_timeout(context)) return NULL;
     if (!object->Has(context, js_name).FromJust()) {
         // TODO fix this so that it works
         PyObject *class_name = py_from_js(object->GetConstructorName(), context);
@@ -104,7 +104,7 @@ PyObject *js_object_getattro(js_object *self, PyObject *name) {
     PY_PROPAGATE_JS;
 
     MaybeLocal<Value> js_value = object->Get(context, js_name);
-    if (!cleanup_timeout(timeout)) return NULL;
+    if (!context_cleanup_timeout(context)) return NULL;
 
     PY_PROPAGATE_JS;
     PyObject *value = py_from_js(js_value.ToLocalChecked(), context);
@@ -134,14 +134,14 @@ int js_object_setattro(js_object *self, PyObject *name, PyObject *value) {
         timeout = ctx_c->timeout;
     }
 
-    if (!setup_timeout(timeout)) return -1;
+    if (!context_setup_timeout(context)) return -1;
 
     if (value != NULL)
         object->Set(context, js_from_py(name, context), js_from_py(value, context));
     else
         object->Delete(context, js_from_py(name, context));
 
-    if (!cleanup_timeout(timeout)) return -1;
+    if (!context_cleanup_timeout(context)) return -1;
 
     PY_PROPAGATE_JS_RET(-1);
 
@@ -175,7 +175,7 @@ PyObject *js_object_dir(js_object *self) {
         timeout = ctx_c->timeout;
     }
 
-    if (!setup_timeout(timeout)) return NULL;
+    if (!context_setup_timeout(context)) return NULL;
     for (unsigned i = 0; i < properties->Length(); i++) {
         MaybeLocal<Value> js_property = properties->Get(context, i);
         PY_PROPAGATE_JS;
@@ -183,7 +183,7 @@ PyObject *js_object_dir(js_object *self) {
         PyList_SET_ITEM(py_properties, i, py_property);
     }
 
-    if (!cleanup_timeout(timeout)) return NULL;
+    if (!context_cleanup_timeout(context)) return NULL;
 
     return py_properties;
 }

--- a/v8py/jsobject.cpp
+++ b/v8py/jsobject.cpp
@@ -136,19 +136,14 @@ int js_object_setattro(js_object *self, PyObject *name, PyObject *value) {
 
     if (!setup_timeout(timeout)) return -1;
 
-    Maybe<bool> result = value ?
-        object->Set(context, js_from_py(name, context), js_from_py(value, context)) :
+    if (value != NULL)
+        object->Set(context, js_from_py(name, context), js_from_py(value, context));
+    else
         object->Delete(context, js_from_py(name, context));
 
     if (!cleanup_timeout(timeout)) return -1;
 
     PY_PROPAGATE_JS_RET(-1);
-
-    if (result.IsNothing() || !result.FromJust()) {
-        PyErr_SetString(PyExc_AttributeError,
-            value ? "Object->Set no such attribute" : "Object->Del no such attribute");
-        return -1;
-    }
 
     return 0;
 }

--- a/v8py/v8py.cpp
+++ b/v8py/v8py.cpp
@@ -91,9 +91,9 @@ PyObject *construct_new_object(PyObject *self, PyObject *args) {
 
     if (!setup_timeout(timeout)) return NULL;
     MaybeLocal<Value> result = object->CallAsConstructor(argc, argv);
+    delete[] argv;
     if (!cleanup_timeout(timeout)) return NULL;
 
-    delete[] argv;
     PY_PROPAGATE_JS;
 
     return py_from_js(result.ToLocalChecked(), context);

--- a/v8py/v8py.cpp
+++ b/v8py/v8py.cpp
@@ -69,12 +69,6 @@ PyObject *construct_new_object(PyObject *self, PyObject *args) {
     IN_CONTEXT(function->context.Get(isolate))
     JS_TRY
 
-    double timeout = 0;
-    {
-        context_c *ctx_c = (context_c *) context->GetEmbedderData(CONTEXT_OBJECT_SLOT).As<External>()->Value();
-        timeout = ctx_c->timeout;
-    }
-
     Local<Object> object = function->object.Get(isolate);
     if (!object->IsConstructor()) {
         PyErr_SetString(PyExc_TypeError, "First argument must be a constructor function.");

--- a/v8py/v8py.cpp
+++ b/v8py/v8py.cpp
@@ -89,10 +89,10 @@ PyObject *construct_new_object(PyObject *self, PyObject *args) {
         argv[i] = js_from_py(PyTuple_GET_ITEM(args, i + 1), context);
     }
 
-    if (!setup_timeout(timeout)) return NULL;
+    if (!context_setup_timeout(context)) return NULL;
     MaybeLocal<Value> result = object->CallAsConstructor(argc, argv);
     delete[] argv;
-    if (!cleanup_timeout(timeout)) return NULL;
+    if (!context_cleanup_timeout(context)) return NULL;
 
     PY_PROPAGATE_JS;
 

--- a/v8py/v8py.cpp
+++ b/v8py/v8py.cpp
@@ -69,6 +69,12 @@ PyObject *construct_new_object(PyObject *self, PyObject *args) {
     IN_CONTEXT(function->context.Get(isolate))
     JS_TRY
 
+    double timeout = 0;
+    {
+        context_c *ctx_c = (context_c *) context->GetEmbedderData(CONTEXT_OBJECT_SLOT).As<External>()->Value();
+        timeout = ctx_c->timeout;
+    }
+
     Local<Object> object = function->object.Get(isolate);
     if (!object->IsConstructor()) {
         PyErr_SetString(PyExc_TypeError, "First argument must be a constructor function.");
@@ -82,7 +88,11 @@ PyObject *construct_new_object(PyObject *self, PyObject *args) {
     for (long i = 0; i < argc; i++) {
         argv[i] = js_from_py(PyTuple_GET_ITEM(args, i + 1), context);
     }
+
+    if (!setup_timeout(timeout)) return NULL;
     MaybeLocal<Value> result = object->CallAsConstructor(argc, argv);
+    if (!cleanup_timeout(timeout)) return NULL;
+
     delete[] argv;
     PY_PROPAGATE_JS;
 


### PR DESCRIPTION
Javascript can hang python from many places!

```python
ctx = Context(timeout=0.1)
# JavaScriptTerminated
ctx.eval("while(true);") 

# old API still works and raises JavaScriptTerminated
ctx.eval("while(true);", timeout=2) 

ctx.eval("function freeze() { while(true); }")
# JavaScriptTerminated
ctx.glob.freeze() 

ctx.eval("function Freeze() { while(true); }")
# JavaScriptTerminated
new(ctx.glob.Freeze)
```

Not anymore.