### PR TITLE
Fixed js_object_cache memory leak

### DIFF
--- a/v8py/context.cpp
+++ b/v8py/context.cpp
@@ -300,7 +300,7 @@ Local<Object> context_get_cached_jsobject(Local<Context> js_context, PyObject *p
 void context_set_cached_jsobject(Local<Context> js_context, PyObject *py_object, Local<Object> object) {
     EscapableHandleScope hs(isolate);
     context_c *self = (context_c *) js_context->GetEmbedderData(CONTEXT_OBJECT_SLOT).As<External>()->Value();
-    js_object *jsobj = js_object_new(object, js_context);
+    js_object *jsobj = js_object_weak_new(object, js_context);
     if (PyObject_SetItem(self->js_object_cache, py_object, (PyObject *) jsobj) < 0) {
         if (PyErr_ExceptionMatches(PyExc_TypeError)) {
             // if it's a type error, it's probably "cannot create weak reference" and should be ignored.

--- a/v8py/jsfunction.cpp
+++ b/v8py/jsfunction.cpp
@@ -24,10 +24,10 @@ int js_function_type_init() {
 
 PyObject *js_function_call(js_function *self, PyObject *args, PyObject *kwargs) {
     IN_V8;
-    IN_CONTEXT(self->context.Get(isolate));
+    Local<Object> object = self->object.Get(isolate);
+    IN_CONTEXT(object->CreationContext());
     JS_TRY
 
-    Local<Object> object = self->object.Get(isolate);
     Local<Value> js_this;
     if (self->js_this.IsEmpty()) {
         js_this = Undefined(isolate);

--- a/v8py/jsobject.h
+++ b/v8py/jsobject.h
@@ -9,12 +9,12 @@ using namespace v8;
 typedef struct {
     PyObject_HEAD
     Persistent<Object> object;
-    Persistent<Context> context;
 } js_object;
 extern PyTypeObject js_object_type;
 int js_object_type_init();
 
 js_object *js_object_new(Local<Object> object, Local<Context> context);
+js_object *js_object_weak_new(Local<Object> object, Local<Context> context);
 PyObject *js_object_fake_new(PyTypeObject *type, PyObject *args, PyObject *kwargs);
 void js_object_dealloc(js_object *self);
 
@@ -28,7 +28,6 @@ PyObject *js_object_repr(js_object *self);
 typedef struct {
     PyObject_HEAD
     Persistent<Object> object;
-    Persistent<Context> context;
     Persistent<Value> js_this;
 } js_function;
 extern PyTypeObject js_function_type;

--- a/v8py/jsobject.h
+++ b/v8py/jsobject.h
@@ -40,7 +40,6 @@ void js_function_dealloc(js_function *self);
 typedef struct {
     PyObject_HEAD
     Persistent<Object> object;
-    Persistent<Context> context;
 } js_promise;
 extern PyTypeObject js_promise_type;
 int js_promise_type_init();

--- a/v8py/v8py.cpp
+++ b/v8py/v8py.cpp
@@ -66,10 +66,10 @@ PyObject *construct_new_object(PyObject *self, PyObject *args) {
     js_function *function = (js_function*)constructor;
 
     IN_V8;
-    IN_CONTEXT(function->context.Get(isolate))
+    Local<Object> object = function->object.Get(isolate);
+    IN_CONTEXT(object->CreationContext())
     JS_TRY
 
-    Local<Object> object = function->object.Get(isolate);
     if (!object->IsConstructor()) {
         PyErr_SetString(PyExc_TypeError, "First argument must be a constructor function.");
         return NULL;


### PR DESCRIPTION
This pull request fixes a memory leak with `js_object_cache` dictionary by using new method `js_object_weak_new` instead of `js_object_new`.

Reference cycle looks like: python object -> js_object (though js_object_cache) -> javascript object -> python object (through weak callback)

`js_object_weak_new` breaks that cycle.

Also, this PR removes unnecessary `context` attribute from `js_function` and `js_object` by using `CreationContext` instead.