### PR TITLE
v8 to perform a clean checkout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ def get_v8():
             run('gclient fetch')
 
     with cd('v8'):
-        run('git checkout {}'.format('branch-heads/5.9'))
+        run('git checkout -f {}'.format('branch-heads/5.9'))
         run('gclient sync')
 
 class BuildV8Command(Command):


### PR DESCRIPTION
5 images files committed on 18th June 2018 with no proper file line endings caused the files to be modified when the v8 repo was cloned on Ubuntu machines. This in turn caused the checkout to branch-heads/5.9 to fail.
Fixes #26