### PR TITLE
Fix binary wheel build step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,13 @@ python:
     - 3.7
     - 3.8
 
-
 install:
     - sudo apt update && sudo apt install patchelf
-    - pip install twine pytest greenstack auditwheel
-    - export CFLAGS='-g -O0 --coverage'
+    - pip install --upgrade pip && pip install twine pytest greenstack auditwheel
 
 script:
     - python ./setup.py bdist_wheel
-    - auditwheel --plat manylinux2014_x86_64 --repair dist/*.whl && rm -rf dist && mv wheelhouse dist
+    - auditwheel repair --plat manylinux2014_x86_64 dist/*.whl && rm -rf dist && mv wheelhouse dist
     - pip install dist/*.whl
     - pytest
     - pip uninstall -y greenstack && python -c "import v8py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,14 @@ python:
 install:
     - sudo apt update && sudo apt install patchelf
     - pip install --upgrade pip && pip install twine pytest greenstack
-    - pip3 install auditwheel
+    # auditwheel is python 3 only, cheat a bit here
+    - ~/virtualenv/python3.6/bin/pip install auditwheel
     - export CFLAGS='-g -O0 --coverage'
 
 script:
     - python ./setup.py bdist_wheel
-    - auditwheel repair --plat manylinux2014_x86_64 dist/*.whl && rm -rf dist && mv wheelhouse dist
+    - ~/virtualenv/python3.6/bin/auditwheel show dist/*.whl
+    - ~/virtualenv/python3.6/bin/auditwheel repair --plat manylinux2014_x86_64 dist/*.whl && rm -rf dist && mv wheelhouse dist
     - pip install dist/*.whl
     - pytest
     - pip uninstall -y greenstack && python -c "import v8py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,40 +1,24 @@
 
 language: python
-sudo: false
+sudo: true
 group: beta
 dist: xenial
-services:
-    - docker
+python:
+    - 2.7
+    - 3.5
+    - 3.6
+    - 3.7
+    - 3.8
 
-jobs:
-    include:
-        - python: 2.7
-          env:
-            - CIBW_BUILD=cp27-manylinux_x86_64
-            - CIBW_MANYLINUX_X86_64_IMAGE=quay.io/pypa/manylinux2014_x86_64:2020-07-27-669fac3
-        - python: 3.5
-          env:
-            - CIBW_BUILD=cp35-manylinux_x86_64
-            - CIBW_MANYLINUX_X86_64_IMAGE=quay.io/pypa/manylinux2014_x86_64:2020-07-27-669fac3
-        - python: 3.6
-          env:
-            - CIBW_BUILD=cp36-manylinux_x86_64
-            - CIBW_MANYLINUX_X86_64_IMAGE=quay.io/pypa/manylinux2014_x86_64:2020-07-27-669fac3
-        - python: 3.7
-          env:
-            - CIBW_BUILD=cp37-manylinux_x86_64
-            - CIBW_MANYLINUX_X86_64_IMAGE=quay.io/pypa/manylinux2014_x86_64:2020-07-27-669fac3
-        - python: 3.8
-          env:
-            - CIBW_BUILD=cp38-manylinux_x86_64
-            - CIBW_MANYLINUX_X86_64_IMAGE=quay.io/pypa/manylinux2014_x86_64:2020-07-27-669fac3
 
 install:
-    - pip install twine pytest greenstack cibuildwheel
+    - sudo apt update && sudo apt install patchelf
+    - pip install twine pytest greenstack auditwheel
     - export CFLAGS='-g -O0 --coverage'
 
 script:
-    - travis_wait 60 cibuildwheel --platform linux --output-dir dist
+    - python ./setup.py bdist_wheel
+    - auditwheel --plat manylinux2014_x86_64 --repair dist/*.whl && rm -rf dist && mv wheelhouse dist
     - pip install dist/*.whl
     - pytest
     - pip uninstall -y greenstack && python -c "import v8py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ python:
 
 install:
     - sudo apt update && sudo apt install patchelf
-    - pip install --upgrade pip && pip install twine pytest greenstack
+    - pip install --upgrade pip && pip install twine pytest
+    # greenstack doesn't build for python 3.7 and above
+    - python -c "import sys; exit(1 if (sys.version_info.major, sys.version_info.minor) > (3, 6) else 0)" && pip install greenstack; true
     # auditwheel is python 3 only, cheat a bit here
     - ~/virtualenv/python3.6/bin/pip install auditwheel
     - export CC=`pwd`/v8/third_party/llvm-build/Release+Asserts/bin/clang
@@ -25,7 +27,7 @@ script:
     - ~/virtualenv/python3.6/bin/auditwheel repair --plat manylinux2014_x86_64 dist/*.whl && rm -rf dist && mv wheelhouse dist
     - pip install dist/*.whl
     - pytest
-    - pip uninstall -y greenstack && python -c "import v8py"
+    - pip uninstall -y greenstack; python -c "import v8py"
 
 
 # it takes ages to compile v8 so don't do it too often

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: python
 sudo: false
 group: beta
-dist: trusty
+dist: bionic
 services:
     - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,44 @@
-language: python
-python:
-    - 2.7
-    - 3.5
-script:
-    - ./setup.py test
-    - pip uninstall -y greenstack && ./setup.py develop && python -c "import v8py"
 
-dist: trusty
+language: python
 sudo: false
 group: beta
+dist: trusty
+services:
+    - docker
+
+jobs:
+    include:
+        - python: 2.7
+          env:
+            - CIBW_BUILD=cp27-manylinux_x86_64
+            - CIBW_MANYLINUX_X86_64_IMAGE=quay.io/pypa/manylinux2014_x86_64:2020-07-27-669fac3
+        - python: 3.5
+          env:
+            - CIBW_BUILD=cp35-manylinux_x86_64
+            - CIBW_MANYLINUX_X86_64_IMAGE=quay.io/pypa/manylinux2014_x86_64:2020-07-27-669fac3
+        - python: 3.6
+          env:
+            - CIBW_BUILD=cp36-manylinux_x86_64
+            - CIBW_MANYLINUX_X86_64_IMAGE=quay.io/pypa/manylinux2014_x86_64:2020-07-27-669fac3
+        - python: 3.7
+          env:
+            - CIBW_BUILD=cp37-manylinux_x86_64
+            - CIBW_MANYLINUX_X86_64_IMAGE=quay.io/pypa/manylinux2014_x86_64:2020-07-27-669fac3
+        - python: 3.8
+          env:
+            - CIBW_BUILD=cp38-manylinux_x86_64
+            - CIBW_MANYLINUX_X86_64_IMAGE=quay.io/pypa/manylinux2014_x86_64:2020-07-27-669fac3
 
 install:
-    - pip install twine pytest greenstack
+    - pip install twine pytest greenstack cibuildwheel
     - export CFLAGS='-g -O0 --coverage'
+
+script:
+    - cibuildwheel --platform linux --output-dir dist
+    - pip install dist/*.whl
+    - pytest
+    - pip uninstall -y greenstack && python -c "import v8py"
+
 
 # it takes ages to compile v8 so don't do it too often
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ install:
     - pip install --upgrade pip && pip install twine pytest greenstack
     # auditwheel is python 3 only, cheat a bit here
     - ~/virtualenv/python3.6/bin/pip install auditwheel
+    - export CC=`pwd`/v8/third_party/llvm-build/Release+Asserts/bin/clang
+    - export CXX=`pwd`/v8/third_party/llvm-build/Release+Asserts/bin/clang++
     - export CFLAGS='-g -O0 --coverage'
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ python:
 
 install:
     - sudo apt update && sudo apt install patchelf
-    - pip install --upgrade pip && pip install twine pytest greenstack auditwheel
+    - pip install --upgrade pip && pip install twine pytest greenstack
+    - pip3 install auditwheel
+    - export CFLAGS='-g -O0 --coverage'
 
 script:
     - python ./setup.py bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: python
 sudo: false
 group: beta
-dist: bionic
+dist: xenial
 services:
     - docker
 
@@ -34,7 +34,7 @@ install:
     - export CFLAGS='-g -O0 --coverage'
 
 script:
-    - cibuildwheel --platform linux --output-dir dist
+    - travis_wait 60 cibuildwheel --platform linux --output-dir dist
     - pip install dist/*.whl
     - pytest
     - pip uninstall -y greenstack && python -c "import v8py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ python:
     - 3.5
     - 3.6
     - 3.7
-    - 3.8
 
 install:
     - sudo apt update && sudo apt install patchelf

--- a/setup.py
+++ b/setup.py
@@ -120,8 +120,7 @@ def get_v8():
     else:
         print('updating depot tools')
         with cd('depot_tools'):
-            run('git checkout master')
-            run('git pull')
+            run('git fetch')
 
     if not os.path.isdir('v8/.git'):
         print('downloading v8')

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ def get_v8():
     else:
         print('updating depot tools')
         with cd('depot_tools'):
-            run('git fetch')
+            run('./update_depot_tools')
 
     if not os.path.isdir('v8/.git'):
         print('downloading v8')

--- a/setup.py
+++ b/setup.py
@@ -155,17 +155,6 @@ class BuildV8Command(Command):
                     run('ninja\\ninja -C out.gn/x64.release d8')
                 else:
                     gypflags = '-Dv8_use_external_startup_data=0 -Dv8_enable_i18n_support=0 -Dv8_enable_inspector=1 -Dwerror=\'\' '
-                    # for some reason, gtest will sometimes fail to build because the weird cmake-gyp bridge generates
-                    # clang calls that exclude the standard header path. we don't need it, skip building it
-                    run('sed -i "s|\'../samples/samples.gyp:\\*\',||g" gypfiles/all.gyp')
-                    run('sed -i "s|\'../test/cctest/cctest.gyp:\\*\',||g" gypfiles/all.gyp')
-                    run('sed -i "s|\'../test/fuzzer/fuzzer.gyp:\\*\',||g" gypfiles/all.gyp')
-                    run('sed -i "s|\'../test/unittests/unittests.gyp:\\*\',||g" gypfiles/all.gyp')
-                    run('sed -i "s|testing/gmock.gyp ||g" Makefile')
-                    run('sed -i "s|testing/gtest.gyp ||g" Makefile')
-                    run('sed -i "s|test/unittests/unittests.gyp ||g" Makefile')
-                    run('sed -i "s|test/cctest/cctest.gyp ||g" Makefile')
-                    run('sed -i "s|test/fuzzer/fuzzer.gyp ||g" Makefile')
                     run('make GYPFLAGS="{}" CFLAGS=-fPIC CXXFLAGS=-fPIC {} -j{}'.format(gypflags, MODE,
                                                                                         multiprocessing.cpu_count()))
 

--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,7 @@ def get_v8():
     else:
         print('updating depot tools')
         with cd('depot_tools'):
+            run('git checkout master')
             run('git pull')
 
     if not os.path.isdir('v8/.git'):
@@ -155,6 +156,17 @@ class BuildV8Command(Command):
                     run('ninja\\ninja -C out.gn/x64.release d8')
                 else:
                     gypflags = '-Dv8_use_external_startup_data=0 -Dv8_enable_i18n_support=0 -Dv8_enable_inspector=1 -Dwerror=\'\' '
+                    # for some reason, gtest will sometimes fail to build because the weird cmake-gyp bridge generates
+                    # clang calls that exclude the standard header path. we don't need it, skip building it
+                    run('sed -i "s|\'../samples/samples.gyp:\\*\',||g" gypfiles/all.gyp')
+                    run('sed -i "s|\'../test/cctest/cctest.gyp:\\*\',||g" gypfiles/all.gyp')
+                    run('sed -i "s|\'../test/fuzzer/fuzzer.gyp:\\*\',||g" gypfiles/all.gyp')
+                    run('sed -i "s|\'../test/unittests/unittests.gyp:\\*\',||g" gypfiles/all.gyp')
+                    run('sed -i "s|testing/gmock.gyp ||g" Makefile')
+                    run('sed -i "s|testing/gtest.gyp ||g" Makefile')
+                    run('sed -i "s|test/unittests/unittests.gyp ||g" Makefile')
+                    run('sed -i "s|test/cctest/cctest.gyp ||g" Makefile')
+                    run('sed -i "s|test/fuzzer/fuzzer.gyp ||g" Makefile')
                     run('make GYPFLAGS="{}" CFLAGS=-fPIC CXXFLAGS=-fPIC {} -j{}'.format(gypflags, MODE,
                                                                                         multiprocessing.cpu_count()))
 


### PR DESCRIPTION
PyPI expects Linux binaries to be built to the manylinux specification. The build toolchain for V8 uses a new-ish glibc, so this process produces manylinux2014-compatible packages.

I've tested the cibuildwheel build process, but the changes to the Travis build script are speculative based on the manual process I used. With luck opening a PR will fire off a proper test.